### PR TITLE
2024012500 release code

### DIFF
--- a/backup/moodle2/backup_panoptosubmission_stepslib.php
+++ b/backup/moodle2/backup_panoptosubmission_stepslib.php
@@ -50,7 +50,9 @@ class backup_panoptosubmission_activity_structure_step extends backup_activity_s
                 'cutofftime',
                 'preventlate',
                 'resubmit',
-                'emailteachers',
+                'sendnotifications',
+                'sendlatenotifications',
+                'sendstudentnotifications',
                 'grade',
                 'timecreated',
                 'timemodified'

--- a/db/install.xml
+++ b/db/install.xml
@@ -12,7 +12,9 @@ xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd">
         <FIELD NAME="timedue" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The time the assignment submissions are due by"/>
         <FIELD NAME="preventlate" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Prevent late submissions"/>
         <FIELD NAME="resubmit" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Allow for resubmissions"/>
-        <FIELD NAME="emailteachers" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Email submissions to the teacher"/>
+        <FIELD NAME="sendnotifications" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Allows the disabling of email notifications."/>
+        <FIELD NAME="sendlatenotifications" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Allows separate enabling of notifications for late student submissions."/>
+        <FIELD NAME="sendstudentnotifications" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Default for send student notifications checkbox when grading."/>
         <FIELD NAME="grade" TYPE="number" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" DECIMALS="2" COMMENT="Maximum grade the assignment is worth"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Time the assignment was created"/>
         <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The time the assignment settings were modified"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -63,5 +63,36 @@ function xmldb_panoptosubmission_upgrade($oldversion) {
         // Panopto savepoint reached.
         upgrade_mod_savepoint(true, 2023012400, 'panoptosubmission');
     }
+
+    if ($oldversion < 2023120100) {
+        $table = new xmldb_table('panoptosubmission');
+
+        // Update 'emailteachers' to 'sendnotifications'.
+        $field = new xmldb_field('emailteachers', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '0', null);
+
+        // Check if field exists.
+        if ($dbman->field_exists($table, $field)) {
+            // Rename field emailteachers to sendnotifications.
+            $dbman->rename_field($table, $field, 'sendnotifications');
+        }
+
+        // Add sendlatenotifications field.
+        $field = new xmldb_field('sendlatenotifications', XMLDB_TYPE_INTEGER,
+            '2', null, XMLDB_NOTNULL, null, '0', 'sendnotifications');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Add sendstudentnotifications field.
+        $field = new xmldb_field('sendstudentnotifications', XMLDB_TYPE_INTEGER,
+            '2', null, XMLDB_NOTNULL, null, '0', 'sendlatenotifications');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Update the savepoint.
+        upgrade_mod_savepoint(true, 2023120100, 'panoptosubmission');
+    }
+
     return true;
 }

--- a/lang/en/panoptosubmission.php
+++ b/lang/en/panoptosubmission.php
@@ -39,7 +39,6 @@ $string['preventlate'] = 'Prevent late submissions';
 $string['preventlate_help'] = 'If enabled, this will prevent students from submitting the assignment after the due date.';
 $string['allowdeleting'] = 'Allow resubmitting';
 $string['allowdeleting_help'] = 'If enabled, students may replace submitted videos. Whether it is possible to submit after the due date is controlled by the \'Prevent late submissions\' setting';
-$string['emailteachers'] = 'Email alerts to teachers';
 $string['emailteachers_help'] = 'If enabled, teachers receive email notification whenever students add or update an assignment submission. Only teachers who are able to grade the particular assignment are notified. So, for example, if the course uses separate groups, teachers restricted to particular groups won\'t receive notification about students in other groups.';
 $string['invalidid'] = 'Invalid ID';
 $string['invalid_launch_parameters'] = 'Invalid launch parameters';
@@ -93,6 +92,16 @@ $string['submission'] = 'Submission';
 $string['submissions'] = 'Submissions';
 $string['gradeitem:submissions'] = 'Submissions';
 $string['feedback'] = 'Feedback';
+$string['feedbackavailabletext'] = '{$a->username} has posted some feedback on your
+assignment submission for \'{$a->assignment}\'
+
+You can see it appended to your assignment submission:
+
+    {$a->url}';
+$string['feedbackavailablehtml'] = '{$a->username} has posted some feedback on your
+assignment submission for \'<i>{$a->assignment}</i>\'<br /><br />
+You can see it appended to your <a href="{$a->url}">assignment submission</a>.';
+$string['feedbackavailablesmall'] = '{$a->username} has given feedback for assignment {$a->assignment}';
 $string['singlesubmissionheader'] = 'Grade submission';
 $string['singlegrade'] = 'Add help text';
 $string['singlegrade_help'] = 'Add help text';
@@ -102,20 +111,27 @@ $string['savedchanges'] = 'Changed Saved';
 $string['save'] = 'Save Changes';
 $string['cancel'] = 'Close';
 $string['pluginname'] = 'Panopto Student Submission';
-$string['emailteachermail'] = '{$a->username} has updated their assignment submission
+$string['gradersubmissionupdatedtext'] = '{$a->username} has updated their assignment submission
 for \'{$a->assignment}\' at {$a->timeupdated}
 
 View the submission here:
 
     {$a->url}';
-$string['emailteachermailhtml'] = '{$a->username} has updated their assignment submission
+$string['gradersubmissionupdatedhtml'] = '{$a->username} has updated their assignment submission
 for <i>\'{$a->assignment}\'  at {$a->timeupdated}</i><br /><br />
 It is <a href="{$a->url}">available on the web site</a>.';
+$string['gradersubmissionupdatedsmall'] = '{$a->username} has updated their submission for assignment {$a->assignment}.';
+$string['submissionreceipttext'] = 'You have submitted an
+assignment submission for \'{$a->assignment}\'
+
+You can see the status of your assignment submission:
+
+    {$a->url}';
+$string['submissionreceipthtml'] = '<p>You have submitted an assignment submission for \'<i>{$a->assignment}</i>\'.</p>
+<p>You can see the status of your <a href="{$a->url}">assignment submission</a>.</p>';
+$string['submissionreceiptsmall'] = 'You have submitted your assignment submission for {$a->assignment}';
 $string['messageprovider:panoptosubmission_updates'] = 'Panopto Student Submission notifications';
 $string['video_preview_header'] = 'Submission preview';
-$string['panoptosubmission:gradesubmission'] = 'Grade video submissions';
-$string['panoptosubmission:addinstance'] = 'Add a Panopto Student Submission activity';
-$string['panoptosubmission:submit'] = 'Submit';
 $string['noenrolledstudents'] = 'No students are enrolled in the course';
 $string['group_filter'] = 'Group Filter';
 $string['noassignments'] = 'No Panopto Student Submission activities found in the course';
@@ -144,6 +160,15 @@ $string['grade_out_of'] = 'Grade out of {$a}: ';
 $string['quickgrade_help'] = 'If enabled, multiple assignments can be graded at the same time. Update grades and feedback and then click "Save all feedback".';
 $string['no_existing_lti_tools'] = 'A preconfigured Panopto LTI tool with the custom parameter "panopto_student_submission_tool" must exist to be able to use the Panopto Student Submission activity. Please see setup documentation for more information.';
 $string['no_automatic_operation_target_server'] = 'Please set Automatic Operation Target Server in the settings, so course can be provisioned.';
+$string['notifications'] = 'Notifications';
+$string['sendstudentnotificationsdefault'] = 'Default for \'Notify student\'';
+$string['sendstudentnotificationsdefault_help'] = 'When grading each student, should \'Notify student\' be ticked by default?';
+$string['sendstudentnotifications'] = 'Notify student';
+$string['sendstudentnotifications_help'] = 'Tick this box to send a notification about the updated grade or feedback. If the assignment uses a marking workflow, or the grades are hidden in the grader report, then the notification will not be sent until the grade is released.';
+$string['sendnotifications'] = 'Notify graders about submissions';
+$string['sendnotifications_help'] = 'If enabled, graders (usually teachers) receive a message whenever a student submits an assignment, early, on time and late.';
+$string['sendlatenotifications'] = 'Notify graders about late submissions';
+$string['sendlatenotifications_help'] = 'If enabled, graders (usually teachers) receive a message whenever a student submits an assignment late.';
 $string['privacy:metadata:emailteachersexplanation'] = 'Messages are sent to teachers through the messaging system.';
 $string['privacy:metadata:panoptosubmission_submission'] = 'Panopto Student Submission submissions';
 $string['privacy:metadata:panoptosubmission_submission:email'] = 'Your email is sent to Panopto to allow use of Panopto\'s email features.';
@@ -163,3 +188,7 @@ $string['privacy:metadata:panoptosubmissionperpage'] = 'Number of assignment sub
 $string['privacy:metadata:panoptosubmissionquickgrade'] = 'Quick grading preference for Panopto Submission.';
 $string['privacy:markedsubmissionspath'] = 'markedsubmissions';
 $string['privacy:submissionpath'] = 'submission';
+$string['panoptosubmission:gradesubmission'] = 'Grade video submissions';
+$string['panoptosubmission:addinstance'] = 'Add a Panopto Student Submission activity';
+$string['panoptosubmission:submit'] = 'Submit';
+$string['panoptosubmission:receivegradernotifications'] = 'Receive grader submission notifications';

--- a/lib.php
+++ b/lib.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * main lib.php file for the Panopto Student Submission mod
+ * Main lib.php file for the Panopto Student Submission mod.
  *
  * @package mod_panoptosubmission
  * @copyright  Panopto 2021
@@ -178,7 +178,6 @@ function panoptosubmission_user_outline($course, $user, $mod, $data) {
     return $return;
 }
 
-
 /**
  * Print a detailed representation of what a user has done with
  * a given particular instance of this module, for user activity reports.
@@ -208,7 +207,6 @@ function panoptosubmission_print_recent_activity($course, $viewfullnames, $times
     return false;
 }
 
-
 /**
  * Must return an array of users who are participants an instance of the
  * Panopto Student Submission activity
@@ -219,7 +217,6 @@ function panoptosubmission_print_recent_activity($course, $viewfullnames, $times
 function panoptosubmission_get_participants($targetactivity) {
     return false;
 }
-
 
 /**
  * This function returns if a scale is being used by one panoptosubmission

--- a/mod_form.php
+++ b/mod_form.php
@@ -82,9 +82,22 @@ class mod_panoptosubmission_mod_form extends moodleform_mod {
         $mform->addHelpButton('resubmit', 'allowdeleting', 'panoptosubmission');
         $mform->setDefault('resubmit', 0);
 
-        $mform->addElement('select', 'emailteachers', get_string('emailteachers', 'panoptosubmission'), $ynoptions);
-        $mform->addHelpButton('emailteachers', 'emailteachers', 'panoptosubmission');
-        $mform->setDefault('emailteachers', 0);
+        // Notifications.
+        $mform->addElement('header', 'notifications', get_string('notifications', 'panoptosubmission'));
+
+        $name = get_string('sendnotifications', 'panoptosubmission');
+        $mform->addElement('selectyesno', 'sendnotifications', $name);
+        $mform->addHelpButton('sendnotifications', 'sendnotifications', 'panoptosubmission');
+
+        $name = get_string('sendlatenotifications', 'panoptosubmission');
+        $mform->addElement('selectyesno', 'sendlatenotifications', $name);
+        $mform->addHelpButton('sendlatenotifications', 'sendlatenotifications', 'panoptosubmission');
+        $mform->disabledIf('sendlatenotifications', 'sendnotifications', 'eq', 1);
+
+        $name = get_string('sendstudentnotificationsdefault', 'panoptosubmission');
+        $mform->addElement('selectyesno', 'sendstudentnotifications', $name);
+        $mform->addHelpButton('sendstudentnotifications', 'sendstudentnotificationsdefault', 'panoptosubmission');
+        $mform->setDefault('sendstudentnotificationsdefault', 0);
 
         $this->standard_grading_coursemodule_elements();
 
@@ -92,8 +105,6 @@ class mod_panoptosubmission_mod_form extends moodleform_mod {
 
         $this->add_action_buttons();
     }
-
-
 
     /**
      * Perform minimal validation on the settings form

--- a/single_submission_form.php
+++ b/single_submission_form.php
@@ -204,6 +204,11 @@ class panoptosubmission_singlesubmission_form extends moodleform {
 
         }
 
+        // Notify student checkbox.
+        $mform->addElement('selectyesno', 'sendstudentnotifications', get_string('sendstudentnotifications', 'panoptosubmission'));
+        $mform->setDefault('sendstudentnotifications', $this->_customdata->cminstance->sendstudentnotifications ?? 0);
+        $mform->setType('sendstudentnotifications', PARAM_BOOL);
+
         $this->add_action_buttons();
     }
 

--- a/submission.php
+++ b/submission.php
@@ -149,8 +149,11 @@ if ($submission) {
 $context = $PAGE->context;
 
 // Email an alert to the teacher.
-if ($pansubmissionactivity->emailteachers) {
-    panoptosubmission_email_teachers($cm, $pansubmissionactivity->name, $submission, $context);
-}
+panoptosubmission_notify_graders($pansubmissionactivity,
+    $submission,
+    $cm,
+    $context,
+    $course);
+
 
 echo $OUTPUT->footer();

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 defined('MOODLE_INTERNAL') || die();
 
 // The current plugin version (Date: YYYYMMDDXX).
-$plugin->version = 2023083100;
+$plugin->version = 2024012500;
 
-// Requires this Moodle version - 2.7.
-$plugin->requires = 2014051202;
+// Requires this Moodle version - 4.1.0
+$plugin->requires = 2022112800;
 
 // Never run cron for this plugin.
 $plugin->cron = 0;


### PR DESCRIPTION
This is the latest stable release of the Panopto Student Submission Activity for Moodle. Once installed, this plugin will add a new Panopto Student Submission Activity to the Activity or Resources section of a course. The new activity allows instructors to create assignments, view the student submissions, and grade them. It also allows students to submit their Panopto videos to be graded.

This version supports (a) Moodle 4.1, 4.2, 4.3 running with PHP 7.4 and 8.0 and (b) Panopto version 10.6.1 or later

Updating the Panopto Student Submission Activity for Moodle plugin to this version also required that you update the Panopto Moodle Block plugin to version 2022122000 or higher.

Below is the list of updates from the previous release (2023083100).

- Added support for Moodle 4.3
- Enabled student notifications for Panopto Student Submission activity
