### PR TITLE
2024120600 release code

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -38,8 +38,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.1'
-            moodle-branch: 'master'
+          - php: '8.3'
+            moodle-branch: 'main'
+            database: 'pgsql'
+          - php: '8.3'
+            moodle-branch: 'MOODLE_404_STABLE'
             database: 'pgsql'
           - php: '8.2'
             moodle-branch: 'MOODLE_403_STABLE'

--- a/lib.php
+++ b/lib.php
@@ -467,6 +467,31 @@ function panoptosubmission_pluginfile(
 }
 
 /**
+ * Retrieve a property in a case-insensitive way and assign default if missing or invalid.
+ *
+ * @param object $object The object to search.
+ * @param string $property The property name to find.
+ * @param mixed $default The default value to return if not found or invalid.
+ */
+function panoptosubmission_get_property_or_default($object, $property, $default) {
+    // Ensure the input is an object, return default otherwise.
+    if (!is_object($object)) {
+        return $default;
+    }
+
+    // Iterate over object properties in a case-insensitive manner.
+    foreach ($object as $key => $value) {
+        if (strcasecmp($key, $property) === 0) { // strcasecmp is case-insensitive.
+            // Return default if the value is strictly 0 or evaluates to false.
+            return ($value === 0 || !$value) ? $default : $value;
+        }
+    }
+
+    // Return default if the property is not found.
+    return $default;
+}
+
+/**
  * Function to be run periodically according to the moodle cron
  *
  * Finds all assignment notifications that have yet to be mailed out, and mails them.

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 // The current plugin version (Date: YYYYMMDDXX).
-$plugin->version = 2024070900;
+$plugin->version = 2024120600;
 
 // Requires this Moodle version - 4.1.0.
 $plugin->requires = 2022112800;


### PR DESCRIPTION
This is the latest release of the Panopto Student Submission Activity for Moodle. Once installed, this plugin will add a new Panopto Student Submission Activity to the Activity or Resources section of a course. The new activity allows instructors to create assignments, view the student submissions, and grade them. It also allows students to submit their Panopto videos to be graded.

This version supports (a) Moodle 4.1, 4.2, 4.3, 4.4, 4.5 running with PHP 7.4, 8.0, and 8.1 and (b) Panopto version 10.6.1 or later

Updating the Panopto Student Submission Activity for Moodle plugin to this version also requires that you update the Panopto Moodle Block plugin to version 2022122000 or higher.

Below is the list of updates from the previous release (2024070900).
- Added support for Moodle 4.5
